### PR TITLE
Point to valid error codes for Example error response

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -523,7 +523,7 @@ info:
 
     | Property      | Description                                                |
     | ------------- | ---------------------------------------------------------- |
-    | code          | The Kivra [error code](#error-codes)                       |
+    | code          | The Kivra [error code](#section/Errors/Error-codes)     |
     | short_message | A short description of the error                           |
     | long_message  | A longer and more verbose error message                    |
 


### PR DESCRIPTION
This change will redirect the error code href to https://developer.kivra.com/#section/Errors/Error-codes. Which is a valid list of error codes