### PR TITLE
[K4B-1801] Add K4B Partner API v3

### DIFF
--- a/assets/redoc-styles.css
+++ b/assets/redoc-styles.css
@@ -3,7 +3,12 @@ body {
   padding: 0;
 }
 
-.menu-content div:first-of-type img {
+/* This alt hack depends on x-logo in swagger.yml,
+ * if you have a better solution that let's us size
+ * our own logo but not the logo in the navbar footer,
+ * feel free to improve this.
+ */
+.menu-content img[alt="Kivra logo"] {
   padding: 20px 0 10px 20px;
   width: 130px;
   height: auto;

--- a/index.html
+++ b/index.html
@@ -19,6 +19,6 @@
   </head>
   <body>
     <redoc spec-url="swagger.yml"></redoc>
-    <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/redoc@2.0.0/bundles/redoc.standalone.js"></script>
   </body>
 </html>

--- a/swagger.yml
+++ b/swagger.yml
@@ -4548,13 +4548,11 @@ components:
     CompanyKey:
       description: The key for a company
       pattern: ^[0-9]{10}[a-f0-9]{32}$
-      description: The unique identifier for the object this key belongs to
       example: 156077433683911cdca5fd4563bded979572454cb9
       type: string
     ContentKey:
       description: The key for a content
       pattern: ^[0-9]{10}[a-f0-9]{32}$
-      description: The unique identifier for the object this key belongs to
       example: 156077433683911cdca5fd4563bded979572454cb9
       type: string
     CompanyType:

--- a/swagger.yml
+++ b/swagger.yml
@@ -4543,21 +4543,36 @@ components:
             The unique key for the content file (present for all content that is not "text/html" or "text/plain")
           example: "15118724482475bf32615b4a2aaa604fd66377010e"
 
+    # ##############################################
+    # SCHEMA EmptyString
+    # ##############################################
     EmptyString:
       description: The empty string
       enum:
         - ''
       type: string
+
+    # ##############################################
+    # SCHEMA CompanyKey
+    # ##############################################
     CompanyKey:
       description: The key for a company
       pattern: ^[0-9]{10}[a-f0-9]{32}$
       example: 156077433683911cdca5fd4563bded979572454cb9
       type: string
+
+    # ##############################################
+    # SCHEMA ContentKey
+    # ##############################################
     ContentKey:
       description: The key for a content
       pattern: ^[0-9]{10}[a-f0-9]{32}$
       example: 156077433683911cdca5fd4563bded979572454cb9
       type: string
+
+    # ##############################################
+    # SCHEMA CompanyType
+    # ##############################################
     CompanyType:
       description: |
         The company's/organisation's type
@@ -4571,10 +4586,18 @@ components:
         - company
         - riksidrottsförening
       type: string
+
+    # ##############################################
+    # SCHEMA CompanyName
+    # ##############################################
     CompanyName:
       description: The name of a company
       example: Cornelias Café AB
       type: string
+
+    # ##############################################
+    # SCHEMA VatNumber
+    # ##############################################
     VatNumber:
       pattern: ^[A-Z]{2}[0-9]{10}[0-9]{2}$
       description: |
@@ -4584,11 +4607,19 @@ components:
         Land code - Organisation number - Serial number
       example: SE556000475501
       type: string
+
+    # ##############################################
+    # SCHEMA IncomingEmail
+    # ##############################################
     IncomingEmail:
       pattern: ^[a-tv-zA-TV-Z0-9]{9}@(sandbox\.)?kivramail.com$
       description: K4B+ email address for receiving emails as content
       type: string
       example: xxcsn2psy@kivramail.com
+
+    # ##############################################
+    # SCHEMA ScanningAddress
+    # ##############################################
     ScanningAddress:
       description: K4B+ postal address for scanning physical post
       additionalProperties: false
@@ -4628,6 +4659,10 @@ components:
         - city
         - country
       type: object
+
+    # ##############################################
+    # SCHEMA AllServices
+    # ##############################################
     AllServices:
       description: All K4B and K4B+ services
       additionalProperties: false
@@ -4657,10 +4692,18 @@ components:
           example: true
           type: boolean
       type: object
+
+    # ##############################################
+    # SCHEMA FieldQueryParameter
+    # ##############################################
     FieldQueryParameter:
       description: The field(s) to respond with
       example: key
       type: string
+
+    # ##############################################
+    # SCHEMA BaseCompany
+    # ##############################################
     BaseCompany:
       description: A company object with basic fields only
       additionalProperties: false
@@ -4674,6 +4717,10 @@ components:
         vat_number:
           $ref: '#/components/schemas/VatNumber'
       type: object
+
+    # ##############################################
+    # SCHEMA FullCompany
+    # ##############################################
     FullCompany:
       description: A company object
       additionalProperties: false
@@ -4704,31 +4751,59 @@ components:
       required:
         - key
       type: object
+
+    # ##############################################
+    # SCHEMA GovernmentalLabel
+    # ##############################################
     GovernmentalLabel:
       description: |
         Indicates if the content comes from a governmental body.
       type: boolean
+
+    # ##############################################
+    # SCHEMA HandledLabel
+    # ##############################################
     HandledLabel:
       description: |
         The content has been marked as `handled`, previously known as `paid`.
       type: boolean
+
+    # ##############################################
+    # SCHEMA InterpretedLabel
+    # ##############################################
     InterpretedLabel:
       description: |
         Indicates if the content has been interpreted.
       type: boolean
+
+    # ##############################################
+    # SCHEMA ReminderLabel
+    # ##############################################
     ReminderLabel:
       description: |
         Indicates if the content, which must be an invoice, is a reminder.
       type: boolean
+
+    # ##############################################
+    # SCHEMA TrashedLabel
+    # ##############################################
     TrashedLabel:
       description: |
         Indicates if the content has been moved to the trash.
       type: boolean
+
+    # ##############################################
+    # SCHEMA ViewedLabel
+    # ##############################################
     ViewedLabel:
       description: |
         The content has been viewed. This can be toggled by the user, i.e. "Mark
         as unread".
       type: boolean
+
+    # ##############################################
+    # SCHEMA PartnerPaymentOption
+    # ##############################################
     PartnerPaymentOption:
       description: One way to pay this invoice
       additionalProperties: false
@@ -4789,6 +4864,10 @@ components:
         - reference_type
         - type
       type: object
+
+    # ##############################################
+    # SCHEMA InvoiceReferences
+    # ##############################################
     InvoiceReferences:
       description: Invoice references
       additionalProperties: false
@@ -4803,10 +4882,18 @@ components:
         - our
         - your
       type: object
+
+    # ##############################################
+    # SCHEMA PartQueryParameter
+    # ##############################################
     PartQueryParameter:
       minimum: 1
       description: The content part to retrive, 1-indexed
       type: integer
+
+    # ##############################################
+    # SCHEMA PartMetadata
+    # ##############################################
     PartMetadata:
       additionalProperties: false
       properties:
@@ -4847,9 +4934,17 @@ components:
         - size
         - url
       type: object
+
+    # ##############################################
+    # SCHEMA ContentPart
+    # ##############################################
     ContentPart:
       description: The actual content, mostly PDF's, but can one of serveral formats.
       type: string
+
+    # ##############################################
+    # SCHEMA ContentMetadata
+    # ##############################################
     ContentMetadata:
       additionalProperties: false
       properties:

--- a/swagger.yml
+++ b/swagger.yml
@@ -2895,6 +2895,9 @@ paths:
             If `vat_number` is given, the repsonse will only include companies with VAT numbers in that list.
             The `field` parameter controls which columns (CSV) or properties (JSON) to include in the response.
           content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BaseCompany'
             text/csv:
               schema:
                 example: |

--- a/swagger.yml
+++ b/swagger.yml
@@ -10,7 +10,7 @@ info:
   title: Kivra Sweden API
   x-logo:
     url: "assets/Kivra_logo_1920X1080_green.png"
-    altText: Kivra logo
+    altText: Kivra logo # don't rename this without fixing assets/redoc-styles.css
   version: v1 and v2
   description: |
     # Receipt API

--- a/swagger.yml
+++ b/swagger.yml
@@ -104,6 +104,7 @@ info:
     | 2022-07-11 | Added state `generating` for agreements |
     | 2022-09-09 | Added v2 of tenant/TKEY/content endpoint |
     | 2022-12-02 | Added Forms BETA endpoints for Sandbox. API not stable. Breaking changes may happen.  |
+    | 2023-03-08 | Added v3 of the company Partner API |
 
     # Terminology
     ### User
@@ -769,7 +770,8 @@ x-tagGroups:
       - "Tenant API - Agreements"
   - name: Partner API
     tags:
-      - "Partner API"
+      - "Partner API v1"
+      - "Partner API v3"
   - name: Company API
     tags:
       - "Company API"
@@ -2672,7 +2674,7 @@ paths:
   /v1/partner/company:
     get:
       tags:
-        - "Partner API"
+        - "Partner API v1"
       summary: Lookup a specific company
       operationId: Find Company
       description: |
@@ -2711,7 +2713,7 @@ paths:
   /v1/partner/company/{companyKey}/content:
     get:
       tags:
-        - "Partner API"
+        - "Partner API v1"
       summary: Get the company inbox
       operationId: Get company inbox
       description: This resource allows to access a high level description for each content in the company inbox, to allow for a first sorting and filtering of the content.
@@ -2742,7 +2744,7 @@ paths:
   /v1/partner/company/{companyKey}/content/{contentKey}:
     get:
       tags:
-        - "Partner API"
+        - "Partner API v1"
       summary: Get metadata for a content.
       operationId: Get content metadata
       description:
@@ -2782,7 +2784,7 @@ paths:
   /v1/partner/company/{companyKey}/content/{contentKey}/file/{fileKey}/raw:
     get:
       tags:
-        - "Partner API"
+        - "Partner API v1"
       summary: Get raw file in binary format
       operationId: Get raw file
       description: This resource allows to get the raw file in binary format.
@@ -2826,7 +2828,7 @@ paths:
   /v1/partner/company/{companyKey}/content/{contentKey}/{status}:
     post:
       tags:
-        - "Partner API"
+        - "Partner API v1"
       summary: Set status for content
       operationId: Set status for content
       description: This resource allows to set the status for a specific content. It is used by the partner to set whether the content should be marked as viewed or paid.
@@ -2863,6 +2865,184 @@ paths:
         content:
           application/json:
             schema: {}
+
+  # ##############################################
+  # GET /v3/partner/company
+  # ##############################################
+  /v3/partner/company:
+    get:
+      tags:
+        - "Partner API v3"
+      summary: List accessible companies
+      operationId: List companies
+      description: List the companies the client has access to
+      parameters:
+        - name: field
+          in: query
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/FieldQueryParameter'
+        - name: vat_number
+          in: query
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/VatNumber'
+      responses:
+        '200':
+          description: >
+            If `vat_number` is given, the repsonse will only include companies with VAT numbers in that list.
+            The `field` parameter controls which columns (CSV) or properties (JSON) to include in the response.
+          content:
+            text/csv:
+              schema:
+                example: |
+                  key,type,name,vat_number
+                  2156077433683911cdca5fd4563bded979572454cb9,company,Cornelias
+                  Café AB,SE556000475501
+                type: string
+
+  # ##############################################
+  # GET /v3/partner/company/COMPKEY
+  # ##############################################
+  /v3/partner/company/{companyKey}:
+    get:
+      tags:
+        - "Partner API v3"
+      summary: Get a single company
+      operationId: Get company
+      description: Get a single company
+      parameters:
+        - name: companyKey
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/CompanyKey'
+        - name: field
+          in: query
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/FieldQueryParameter'
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FullCompany'
+
+  # ##############################################
+  # GET /v3/partner/company/COMPKEY/content
+  # ##############################################
+  /v3/partner/company/{companyKey}/content:
+    get:
+      tags:
+        - "Partner API v3"
+      summary: List company inbox content
+      operationId: GET_company-companyKey-content
+      description: >
+        List the content this company has received.
+        This may be filtered by certain `labels` and specific fields may be selected using `field`.
+      parameters:
+        - name: companyKey
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/CompanyKey'
+        - name: handled
+          in: query
+          schema:
+            $ref: '#/components/schemas/HandledLabel'
+        - name: viewed
+          in: query
+          schema:
+            $ref: '#/components/schemas/ViewedLabel'
+        - name: field
+          in: query
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/FieldQueryParameter'
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ContentMetadata'
+
+  # ##############################################
+  # GET,PATCH /v3/partner/company/COMPKEY/content/CONTKEY
+  # ##############################################
+  /v3/partner/company/{companyKey}/content/{contentKey}:
+    get:
+      tags:
+        - "Partner API v3"
+      summary: Get specific content
+      operationId: Get content
+      parameters:
+        - name: companyKey
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/CompanyKey'
+        - name: contentKey
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/ContentKey'
+        - name: part
+          in: query
+          schema:
+            $ref: '#/components/schemas/PartQueryParameter'
+      responses:
+        '200':
+          description: Content metadata
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/ContentPart'
+    patch:
+      tags:
+        - "Partner API v3"
+      summary: Update content metadata
+      operationId: Update content metadata
+      parameters:
+        - name: companyKey
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/CompanyKey'
+        - name: contentKey
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/ContentKey'
+      responses:
+        '200':
+          description: Content metadata
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/ContentPart'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              additionalProperties: false
+              properties:
+                handled:
+                  description: Mark the content as `handled`/`unhandled`
+                  $ref: '#/components/schemas/HandledLabel'
+                viewed:
+                  description: Mark the content as `viewed`/`unviewed`
+                  $ref: '#/components/schemas/ViewedLabel'
+              type: object
+        required: true
 
   # ##############################################
   # POST /v3/company/match/plus_active
@@ -4359,6 +4539,414 @@ components:
           description: |
             The unique key for the content file (present for all content that is not "text/html" or "text/plain")
           example: "15118724482475bf32615b4a2aaa604fd66377010e"
+
+    EmptyString:
+      description: The empty string
+      enum:
+        - ''
+      type: string
+    CompanyKey:
+      description: The key for a company
+      pattern: ^[0-9]{10}[a-f0-9]{32}$
+      description: The unique identifier for the object this key belongs to
+      example: 156077433683911cdca5fd4563bded979572454cb9
+      type: string
+    ContentKey:
+      description: The key for a content
+      pattern: ^[0-9]{10}[a-f0-9]{32}$
+      description: The unique identifier for the object this key belongs to
+      example: 156077433683911cdca5fd4563bded979572454cb9
+      type: string
+    CompanyType:
+      description: |
+        The company's/organisation's type
+
+        This is currently based on the registry holding the signatory
+        information. Thus `company` really means that Bolagsverket is the
+        registry and includes Ekonomiska föreningar as well. For
+        `riksidrottsförening` it is Riksindrottsförbundet.
+      example: company
+      enum:
+        - company
+        - riksidrottsförening
+      type: string
+    CompanyName:
+      description: The name of a company
+      example: Cornelias Café AB
+      type: string
+    VatNumber:
+      pattern: ^[A-Z]{2}[0-9]{10}[0-9]{2}$
+      description: |
+        The VAT number of the company.
+
+        It follows this format:
+        Land code - Organisation number - Serial number
+      example: SE556000475501
+      type: string
+    IncomingEmail:
+      pattern: ^[a-tv-zA-TV-Z0-9]{9}@(sandbox\.)?kivramail.com$
+      description: K4B+ email address for receiving emails as content
+      type: string
+      example: xxcsn2psy@kivramail.com
+    ScanningAddress:
+      description: K4B+ postal address for scanning physical post
+      additionalProperties: false
+      properties:
+        name:
+          $ref: '#/components/schemas/CompanyName'
+        street:
+          description: |
+            A special "street" that allows the scanning facility to send to the correct company.
+
+            It's on the format "Kivra: <organisation number>"
+          type: string
+          example: 'Kivra: 556000-4755'
+        postal_code:
+          description: |
+            The special postal code that goes to Kivra's scanning facility
+          example: 106 31
+          enum:
+            - 106 31
+          type: string
+        city:
+          description: The "city" for Kivra's scanning facility
+          example: Stockholm
+          enum:
+            - Stockholm
+          type: string
+        country:
+          description: The country for Kivra's scanning facility
+          example: SE
+          enum:
+            - SE
+          type: string
+      required:
+        - name
+        - street
+        - postal_code
+        - city
+        - country
+      type: object
+    AllServices:
+      description: All K4B and K4B+ services
+      additionalProperties: false
+      properties:
+        email:
+          description: The K4B+ email service
+          example: false
+          type: boolean
+        scanning:
+          description: The K4B+ physical scanned post service
+          example: false
+          type: boolean
+        interpreter:
+          description: The K4B+ interpreter (ML) service
+          example: false
+          type: boolean
+        kivra:
+          description: Kivra's normal postal service, is always enabled
+          example: true
+          enum:
+            - true
+          type: boolean
+        minameddelanden:
+          description: |
+            Governmental posts, only available for companies with `type`
+            `company`
+          example: true
+          type: boolean
+      type: object
+    FieldQueryParameter:
+      description: The field(s) to respond with
+      example: key
+      type: string
+    BaseCompany:
+      description: A company object with basic fields only
+      additionalProperties: false
+      properties:
+        key:
+          $ref: '#/components/schemas/CompanyKey'
+        name:
+          $ref: '#/components/schemas/CompanyName'
+        type:
+          $ref: '#/components/schemas/CompanyType'
+        vat_number:
+          $ref: '#/components/schemas/VatNumber'
+      type: object
+    FullCompany:
+      description: A company object
+      additionalProperties: false
+      properties:
+        key:
+          $ref: '#/components/schemas/CompanyKey'
+        address:
+          oneOf:
+            - $ref: '#/components/schemas/ScanningAddress'
+            - type: nil
+        created_at:
+          description: When the company started to onboard
+          example: '2019-02-26T14:47:26Z'
+          type: string
+          format: date-time
+        email:
+          oneOf:
+            - $ref: '#/components/schemas/IncomingEmail'
+            - $ref: '#/components/schemas/EmptyString'
+        name:
+          $ref: '#/components/schemas/CompanyName'
+        type:
+          $ref: '#/components/schemas/CompanyType'
+        services:
+          $ref: '#/components/schemas/AllServices'
+        vat_number:
+          $ref: '#/components/schemas/VatNumber'
+      required:
+        - key
+      type: object
+    GovernmentalLabel:
+      description: |
+        Indicates if the content comes from a governmental body.
+      type: boolean
+    HandledLabel:
+      description: |
+        The content has been marked as `handled`, previously known as `paid`.
+      type: boolean
+    InterpretedLabel:
+      description: |
+        Indicates if the content has been interpreted.
+      type: boolean
+    ReminderLabel:
+      description: |
+        Indicates if the content, which must be an invoice, is a reminder.
+      type: boolean
+    TrashedLabel:
+      description: |
+        Indicates if the content has been moved to the trash.
+      type: boolean
+    ViewedLabel:
+      description: |
+        The content has been viewed. This can be toggled by the user, i.e. "Mark
+        as unread".
+      type: boolean
+    PartnerPaymentOption:
+      description: One way to pay this invoice
+      additionalProperties: false
+      properties:
+        account:
+          description: The account to pay to
+          example: '12345678'
+          oneOf:
+            - type: string
+            - type: nil
+        amount:
+          minimum: 0
+          description: The amount to pay in öre, or equivalent
+          example: 150000
+          type: integer
+        currency:
+          description: The currency used for this payment option
+          example: SEK
+          oneOf:
+            - type: string
+            - type: nil
+        description:
+          description: The description of this payment, if available
+          example: Takplåt
+          oneOf:
+            - type: string
+            - type: nil
+        due_at:
+          example: '2022-03-30T00:00:00Z'
+          oneOf:
+            - type: string
+              format: date-time
+            - type: nil
+        reference:
+          description: |
+            The payments reference, could be an OCR number of invoice reference
+          example: 987654321
+          oneOf:
+            - type: string
+            - type: nil
+        reference_type:
+          description: The type of reference
+          oneOf:
+            - type: string
+            - type: nil
+        type:
+          description: The type of the the payment, aka the type of the account
+          oneOf:
+            - type: string
+            - type: nil
+      required:
+        - account
+        - amount
+        - currency
+        - description
+        - due_at
+        - reference
+        - reference_type
+        - type
+      type: object
+    InvoiceReferences:
+      description: Invoice references
+      additionalProperties: false
+      properties:
+        our:
+          description: Our reference, "vår referens" in Swedish
+          type: string
+        your:
+          description: Your reference, "er referens" in Swedish
+          type: string
+      required:
+        - our
+        - your
+      type: object
+    PartQueryParameter:
+      minimum: 1
+      description: The content part to retrive, 1-indexed
+      type: integer
+    PartMetadata:
+      additionalProperties: false
+      properties:
+        content_type:
+          description: The MIME type of this content part
+          enum:
+            - application/pdf
+            - text/html
+            - text/plain
+            - image/jpeg
+            - image/gif
+            - image/png
+            - text/calendar
+            - application/msword
+            - >-
+              application/vnd.openxmlformats-officedocument.wordprocessingml.document
+            - >-
+              application/vnd.openxmlformats-officedocument.wordprocessingml.template
+          type: string
+        name:
+          description: The name of this content part. Usually a filename.
+          type: string
+          example: faktura.pdf
+        sha256:
+          description: The SHA256 digest of this content part
+          type: string
+        size:
+          minimum: 0
+          description: The size in bytes of this content part
+          type: integer
+        url:
+          description: The URL to fetch this content part
+          type: string
+      required:
+        - content_type
+        - name
+        - sha256
+        - size
+        - url
+      type: object
+    ContentPart:
+      description: The actual content, mostly PDF's, but can one of serveral formats.
+      type: string
+    ContentMetadata:
+      additionalProperties: false
+      properties:
+        key:
+          $ref: '#/components/schemas/ContentKey'
+        labels:
+          additionalProperties: false
+          properties:
+            governmental:
+              $ref: '#/components/schemas/GovernmentalLabel'
+            handled:
+              $ref: '#/components/schemas/HandledLabel'
+            interpreted:
+              $ref: '#/components/schemas/InterpretedLabel'
+            reminder:
+              $ref: '#/components/schemas/ReminderLabel'
+            trashed:
+              $ref: '#/components/schemas/TrashedLabel'
+            viewed:
+              $ref: '#/components/schemas/ViewedLabel'
+          required:
+            - governmental
+            - handled
+            - interpreted
+            - reminder
+            - trashed
+            - viewed
+          type: object
+        parts:
+          type: array
+          items:
+            $ref: '#/components/schemas/PartMetadata'
+        payment_options:
+          type: array
+          items:
+            $ref: '#/components/schemas/PartnerPaymentOption'
+        references:
+          $ref: '#/components/schemas/InvoiceReferences'
+        received_at:
+          type: string
+          format: date-time
+        receiver_name:
+          type: string
+        receiver_vat_number:
+          $ref: '#/components/schemas/VatNumber'
+        sender_name:
+          type: string
+        sender_vat_numbers:
+          type: array
+          items:
+            $ref: '#/components/schemas/VatNumber'
+        subject:
+          type: string
+        transaction_at:
+          description: |
+            The date and time this content conceptually took place.
+
+            + For a normal `invoice` it is the invoice date.
+            + For a reminder `invoice` it is the reminder data, not the original
+              invoice date.
+            + For a `receipt` it is its transaction date.
+            + For all `other` types of content it is when the sender
+              generated/created the content.
+          type: string
+          format: date-time
+        type:
+          description: |
+            The type of the content
+
+            This is reduced to just three things, an `invoice`, a `receipt` and
+            all `other` types of content.
+          enum:
+            - invoice
+            - receipt
+            - other
+          type: string
+        vat_amount:
+          description: The VAT in öre for this invoice, if available
+          example: 1500
+          oneOf:
+            - type: integer
+            - type: nil
+      required:
+        - key
+        - labels
+        - parts
+        - payment_options
+        - references
+        - received_at
+        - receiver_name
+        - receiver_vat_number
+        - sender_name
+        - sender_vat_numbers
+        - subject
+        - transaction_at
+        - type
+        - vat_amount
+      type: object
 
   # ##############################################
   # SECURITY oAuth2Client


### PR DESCRIPTION
## Problem

We have docs for the v3 partner API we are working on, but they are just in a file in kivra_core. It seems like we didn't find this repository where the real docs are. Of course we want to be able to just point partner developers towards a kivra.com link where they can reference our API docs.

See https://kivra.atlassian.net/browse/K4B-1801

## Solution

You're looking at it!

The docs in kivra_core were written in RAML 1.0, but using https://github.com/daviemakz/oas-raml-converter-cli I could translate it to OpenAPI 3.

In order to not mix up the v1 and v3 apis I gave them a tag each, this makes them show up as separate lists in the navbar.
_edit_: I just saw on I noticed looking at https://developer.kivra.net/#tag/User that we for multi version APIs have put them in the same list but put the version in parenthesis next to the summary. I can do that here as well.

![Screenshot 2023-03-08 at 16 56 30](https://user-images.githubusercontent.com/114754609/223763937-0364e30f-c08e-470c-9b95-cfe509440171.png)

## Bonus

I fixed the weirdly huge redoc logo at the bottom of our navbar @paolokivra 👌 

| Version | Look |
|-|-|
| Current | ![Screenshot 2023-03-08 at 16 48 07](https://user-images.githubusercontent.com/114754609/223763492-45bf0a59-f5df-480b-a7c3-cda02f7344a9.png) |
| Fixed | ![Screenshot 2023-03-08 at 16 48 17](https://user-images.githubusercontent.com/114754609/223763499-3f934c26-72f5-4545-975e-dd229122028e.png) |
