### PR TITLE
feat: [STS-2212] Allow for `days_to_expiry` in kivra/forms

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -4657,6 +4657,8 @@ components:
             internal_id: "6eb7d1b9-ccd6-408f-ade7-9a1837be3ecf"
         days_to_expiry:
           type: integer
+          minimum: 1
+          maximum: 90
           description: >
             Number of days during which the form can accept answers (until 23:59:59).
 

--- a/swagger.yml
+++ b/swagger.yml
@@ -4660,8 +4660,9 @@ components:
           description: >
             Number of days during which the form can accept answers (until 23:59:59).
 
-            As an *example*, if now is September 8th, and the form expires in 30 days,
-            it will effectively expire on October 7th 23:59:59.
+            As an *example*, if *the content is sent* on September 8th,
+            and the form expires in 30 days, it will effectively expire
+            on October 7th 23:59:59.
           example: 30
 
     # ##############################################

--- a/swagger.yml
+++ b/swagger.yml
@@ -2237,6 +2237,7 @@ paths:
                     id: 2877d684-a340-4e4c-867f-d93283787b01
                     sender_reference:
                       internal_id: 6eb7d1b9-ccd6-408f-ade7-9a1837be3ecf
+                    days_to_expiry: 30
                   parts:
                     name: document.pdf
                     data: REVBREJFRUY=
@@ -4641,6 +4642,7 @@ components:
     Form:
       required:
         - id
+        - days_to_expiry
       type: object
       properties:
         id:
@@ -4653,6 +4655,14 @@ components:
           description: Reference data you want to include in the form response.
           example:
             internal_id: "6eb7d1b9-ccd6-408f-ade7-9a1837be3ecf"
+        days_to_expiry:
+          type: integer
+          description: >
+            Number of days during which the form can accept answers (until 23:59:59).
+
+            As an *example*, if now is September 8th, and the form expires in 30 days,
+            it will effectively expire on October 7th 23:59:59.
+          example: 30
 
     # ##############################################
     # SCHEMA Campaign

--- a/swagger.yml
+++ b/swagger.yml
@@ -4660,7 +4660,8 @@ components:
           minimum: 1
           maximum: 90
           description: >
-            Number of days during which the form can accept answers (until 23:59:59).
+            Number of days in which a response to the form can be submitted
+            (until 23:59:59).
 
             As an *example*, if *the content is sent* on September 8th,
             and the form expires in 30 days, it will effectively expire


### PR DESCRIPTION
## Motivation

As per [STS-2212](https://kivra.atlassian.net/browse/STS-2212), `kivra/forms` will require a new (mandatory) field for "days to expiry".

[STS-2212]: https://kivra.atlassian.net/browse/STS-2212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ