### PR TITLE
feat: [STS-2437] documentation for new properties `min` and `max`, for Forms' question type `number`

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -3600,6 +3600,14 @@ components:
             When `type` is `options` then use this to specify the answers that the user can select.
           items:
             $ref: "#/components/schemas/FormOption"
+        min:
+          type: number
+          description: |
+            When `type` is `number` then use this to specify the minimum (inclusive) value to accept in the response.
+        max:
+          type: number
+          description: |
+            When `type` is `number` then use this to specify the maximum (inclusive) value to accept in the response.
     FormOption:
       type: object
       required:


### PR DESCRIPTION
## Description

I copy-pasted `options` (just above it) and adapted the text to the new properties, `min` and `max` to be used in the scope of `type`=`number`.

## Remarks

I do find that having it like this hinders readability, because we start having many optionals depending on the question `type`, but still I'm opening this to discussion and/or approval, as-is.