### PR TITLE
State that services might also implement extra properties in Error objects

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -577,7 +577,7 @@ info:
 
     Extra properties, for further context, can also exist in the error object, for which
     `long_message` should include human-readable information on how to proceed.
-    These are usually documented on a per-path/verb basis.
+    These are documented on a per-path/verb basis.
 
     ## Extended error code
 

--- a/swagger.yml
+++ b/swagger.yml
@@ -576,7 +576,7 @@ info:
     | long_message  | A longer and more verbose error message                    |
 
     Extra properties, for further context, can also exist in the error object, for which
-    `long_message` will usually include human-readable information on how to handle the error.
+    `long_message` should include human-readable information on how to proceed.
     These are usually documented on a per-path/verb basis.
 
     ## Extended error code

--- a/swagger.yml
+++ b/swagger.yml
@@ -575,6 +575,10 @@ info:
     | short_message | A short description of the error                           |
     | long_message  | A longer and more verbose error message                    |
 
+    Extra properties, for further context, can also exist in the error object, for which
+    `long_message` will usually include human-readable information on how to handle the error.
+    These are usually documented on a per-path/verb basis.
+
     ## Extended error code
 
     The 5-digits extended error code is provided both in the body of the response and in the `x-error-code` filed of the response header.


### PR DESCRIPTION
Such is the case with Forms, for example, that'll include an error where the long message is

```
See `violations` for details
```

and then the `violations` property will have human readable information for further context.