### PR TITLE
fix: form listing

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -2441,9 +2441,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/FormTemplateKey"
+                $ref: "#/components/schemas/FormTemplateListing"
         401:
           description: |
             Not authorized to make the request
@@ -3639,12 +3637,33 @@ components:
       required:
         - form_template_key
       properties:
-        form_template_key:
+        key:
           type: string
           description: |
             A key used to identify the form template.
           example:
             2877d684-a340-4e4c-867f-d93283787b01
+
+    FormTemplateListing:
+      type: object
+      required:
+        - forms
+      properties:
+        forms:
+          type: array
+          description: |
+            An entry per form template
+          items:
+            type: object
+            required:
+              - key
+              - response_count
+            properties:
+              key:
+                $ref: "#/components/schemas/FormTemplateKey"
+              response_count:
+                type: integer
+                minimum: 0
 
     # ##############################################
     # SCHEMA Form Response

--- a/swagger.yml
+++ b/swagger.yml
@@ -3636,6 +3636,7 @@ components:
       type: object
       required:
         - form_template_key
+        - response_count
       properties:
         key:
           type: string
@@ -3643,6 +3644,11 @@ components:
             A key used to identify the form template.
           example:
             2877d684-a340-4e4c-867f-d93283787b01
+        response_count:
+          type: integer
+          minimum: 0
+          description: |
+            Count of responses available to collect from this template key
 
     FormTemplateListing:
       type: object
@@ -3652,18 +3658,9 @@ components:
         forms:
           type: array
           description: |
-            An entry per form template
+            form template details
           items:
-            type: object
-            required:
-              - key
-              - response_count
-            properties:
-              key:
-                $ref: "#/components/schemas/FormTemplateKey"
-              response_count:
-                type: integer
-                minimum: 0
+            $ref: "#/components/schemas/FormTemplateKey"
 
     # ##############################################
     # SCHEMA Form Response


### PR DESCRIPTION
Inspect the changes here, the documentation has been lagging behind that the response is an object with the key "forms" and it contains a list of objects with a field called "key" containing the form template key.

https://developer.kivra.com/fix-form-listing/index.html#tag/Tenant-API-Forms-(BETA)/operation/getFormTemplateKey

https://developer.kivra.com/index.html#tag/Tenant-API-Forms-(BETA)/operation/getFormTemplateKey

But also, I recently added a "response_count" field that is how many responses there are in our database connected to that form template key. This is a shortcut for polling implementations that can see what templates to list responses to get response gets to fetch-and-delete, when done they can list templates again and see that the response count is 0.

```json
{
  "forms": [
    {
      "key": "f26ec01d-1c59-4a7d-bfdf-2107e63712bf",
      "response_count": 0
    },
    {
      "key": "e4da87fb-a978-476c-ad2f-b02374ed1fc8",
      "response_count": 67
    }
  ]
}

```