### PR TITLE
Made v2 content subject and type required

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -3382,6 +3382,9 @@ components:
     # ##############################################
     Content_user_v2:
       type: object
+      required:
+        - type
+        - subject
       properties:
         ssn:
           description: |


### PR DESCRIPTION
In v2/tenant/TKEY/content we want in the future to require that tenant sends in subject and a typed content. This is just a start to inform senders to add these.