### PR TITLE
feat: remove beta flag campaign by tag

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -4858,7 +4858,6 @@ components:
     # ##############################################
     Campaign:
       type: object
-      description: This is BETA and only available in Sandbox. As such this may change.
       required:
         - tag
       properties:


### PR DESCRIPTION
As we are releasing the new campaigns by tag feature we can remove the BETA tag from the docs