### PR TITLE
parts in example should be array not object

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -2047,13 +2047,13 @@ paths:
                   generated_at: "2016-12-12"
                   type: "invoice"
                   parts:
-                    name: document.pdf
-                    data: REVBREJFRUY=
-                    content_type: application/pdf
-                    responsive_part:
-                      name: document.html
-                      data: PGgxPmNvbnRlbnQgMTwvaDE+CjxwPmNvbnRlbnQgMTwvcD4=
-                      content_type: text/html
+                    - name: document.pdf
+                      data: REVBREJFRUY=
+                      content_type: application/pdf
+                      responsive_part:
+                        name: document.html
+                        data: PGgxPmNvbnRlbnQgMTwvaDE+CjxwPmNvbnRlbnQgMTwvcD4=
+                        content_type: text/html
                   payment:
                     payable: true
                     currency: SEK
@@ -2070,13 +2070,13 @@ paths:
                   generated_at: "2016-12-12"
                   type: "invoice"
                   parts:
-                    name: document.pdf
-                    data: REVBREJFRUY=
-                    content_type: application/pdf
-                    responsive_part:
-                      name: document.html
-                      data: PGgxPmNvbnRlbnQgMTwvaDE+CjxwPmNvbnRlbnQgMTwvcD4=
-                      content_type: text/html
+                    - name: document.pdf
+                      data: REVBREJFRUY=
+                      content_type: application/pdf
+                      responsive_part:
+                        name: document.html
+                        data: PGgxPmNvbnRlbnQgMTwvaDE+CjxwPmNvbnRlbnQgMTwvcD4=
+                        content_type: text/html
                   payment:
                     payable: true
                     currency: SEK
@@ -2095,13 +2095,13 @@ paths:
                   generated_at: "2016-12-12"
                   type: "invoice"
                   parts:
-                    name: document.pdf
-                    data: REVBREJFRUY=
-                    content_type: application/pdf
-                    responsive_part:
-                      name: document.html
-                      data: PGgxPmNvbnRlbnQgMTwvaDE+CjxwPmNvbnRlbnQgMTwvcD4=
-                      content_type: text/html
+                    - name: document.pdf
+                      data: REVBREJFRUY=
+                      content_type: application/pdf
+                      responsive_part:
+                        name: document.html
+                        data: PGgxPmNvbnRlbnQgMTwvaDE+CjxwPmNvbnRlbnQgMTwvcD4=
+                        content_type: text/html
                   payment_multiple_options:
                     payable: true
                     currency: SEK
@@ -2175,13 +2175,13 @@ paths:
                   generated_at: "2016-12-12"
                   type: "letter"
                   parts:
-                    name: document.pdf
-                    data: REVBREJFRUY=
-                    content_type: application/pdf
-                    responsive_part:
-                      name: document.html
-                      data: PGgxPmNvbnRlbnQgMTwvaDE+CjxwPmNvbnRlbnQgMTwvcD4=
-                      content_type: text/html
+                    - name: document.pdf
+                      data: REVBREJFRUY=
+                      content_type: application/pdf
+                      responsive_part:
+                        name: document.html
+                        data: PGgxPmNvbnRlbnQgMTwvaDE+CjxwPmNvbnRlbnQgMTwvcD4=
+                        content_type: text/html
               letter to user (identified by email):
                 value:
                   email: "someone@example.com"
@@ -2189,13 +2189,13 @@ paths:
                   generated_at: "2016-12-12"
                   type: "letter"
                   parts:
-                    name: document.pdf
-                    data: REVBREJFRUY=
-                    content_type: application/pdf
-                    responsive_part:
-                      name: document.html
-                      data: PGgxPmNvbnRlbnQgMTwvaDE+CjxwPmNvbnRlbnQgMTwvcD4=
-                      content_type: text/html
+                    - name: document.pdf
+                      data: REVBREJFRUY=
+                      content_type: application/pdf
+                      responsive_part:
+                        name: document.html
+                        data: PGgxPmNvbnRlbnQgMTwvaDE+CjxwPmNvbnRlbnQgMTwvcD4=
+                        content_type: text/html
               payslip to user:
                 value:
                   ssn: "191212121212"
@@ -2205,13 +2205,13 @@ paths:
                   retain: true
                   retention_time: "390"
                   parts:
-                    name: document.pdf
-                    data: REVBREJFRUY=
-                    content_type: application/pdf
-                    responsive_part:
-                      name: document.html
-                      data: PGgxPmNvbnRlbnQgMTwvaDE+CjxwPmNvbnRlbnQgMTwvcD4=
-                      content_type: text/html
+                    - name: document.pdf
+                      data: REVBREJFRUY=
+                      content_type: application/pdf
+                      responsive_part:
+                        name: document.html
+                        data: PGgxPmNvbnRlbnQgMTwvaDE+CjxwPmNvbnRlbnQgMTwvcD4=
+                        content_type: text/html
               creditnotice to user:
                 value:
                   ssn: "191212121212"
@@ -2221,13 +2221,13 @@ paths:
                   retain: true
                   retention_time: "30"
                   parts:
-                    name: document.pdf
-                    data: REVBREJFRUY=
-                    content_type: application/pdf
-                    responsive_part:
-                      name: document.html
-                      data: PGgxPmNvbnRlbnQgMTwvaDE+CjxwPmNvbnRlbnQgMTwvcD4=
-                      content_type: text/html
+                    - name: document.pdf
+                      data: REVBREJFRUY=
+                      content_type: application/pdf
+                      responsive_part:
+                        name: document.html
+                        data: PGgxPmNvbnRlbnQgMTwvaDE+CjxwPmNvbnRlbnQgMTwvcD4=
+                        content_type: text/html
               booking to user:
                 value:
                   ssn: "191212121212"
@@ -2235,13 +2235,13 @@ paths:
                   generated_at: "2016-12-12"
                   type: "booking"
                   parts:
-                    name: document.pdf
-                    data: REVBREJFRUY=
-                    content_type: application/pdf
-                    responsive_part:
-                      name: document.html
-                      data: PGgxPmNvbnRlbnQgMTwvaDE+CjxwPmNvbnRlbnQgMTwvcD4=
-                      content_type: text/html
+                    - name: document.pdf
+                      data: REVBREJFRUY=
+                      content_type: application/pdf
+                      responsive_part:
+                        name: document.html
+                        data: PGgxPmNvbnRlbnQgMTwvaDE+CjxwPmNvbnRlbnQgMTwvcD4=
+                        content_type: text/html
                   booking:
                     title: "Appointment"
                     start_time: "2026-12-12T10:00:00Z"
@@ -2256,13 +2256,13 @@ paths:
                   generated_at: "2016-12-12"
                   type: "invoice.debtcampaign"
                   parts:
-                    name: document.pdf
-                    data: REVBREJFRUY=
-                    content_type: application/pdf
-                    responsive_part:
-                      name: document.html
-                      data: PGgxPmNvbnRlbnQgMTwvaDE+CjxwPmNvbnRlbnQgMTwvcD4=
-                      content_type: text/html
+                    - name: document.pdf
+                      data: REVBREJFRUY=
+                      content_type: application/pdf
+                      responsive_part:
+                        name: document.html
+                        data: PGgxPmNvbnRlbnQgMTwvaDE+CjxwPmNvbnRlbnQgMTwvcD4=
+                        content_type: text/html
                   payment:
                     payable: true
                     currency: SEK
@@ -2279,13 +2279,13 @@ paths:
                   generated_at: "2016-12-12"
                   type: "invoice.reminder"
                   parts:
-                    name: document.pdf
-                    data: REVBREJFRUY=
-                    content_type: application/pdf
-                    responsive_part:
-                      name: document.html
-                      data: PGgxPmNvbnRlbnQgMTwvaDE+CjxwPmNvbnRlbnQgMTwvcD4=
-                      content_type: text/html
+                    - name: document.pdf
+                      data: REVBREJFRUY=
+                      content_type: application/pdf
+                      responsive_part:
+                        name: document.html
+                        data: PGgxPmNvbnRlbnQgMTwvaDE+CjxwPmNvbnRlbnQgMTwvcD4=
+                        content_type: text/html
                   payment:
                     payable: true
                     currency: SEK
@@ -2302,13 +2302,13 @@ paths:
                   generated_at: "2016-12-12"
                   type: "invoice.renewal"
                   parts:
-                    name: document.pdf
-                    data: REVBREJFRUY=
-                    content_type: application/pdf
-                    responsive_part:
-                      name: document.html
-                      data: PGgxPmNvbnRlbnQgMTwvaDE+CjxwPmNvbnRlbnQgMTwvcD4=
-                      content_type: text/html
+                    - name: document.pdf
+                      data: REVBREJFRUY=
+                      content_type: application/pdf
+                      responsive_part:
+                        name: document.html
+                        data: PGgxPmNvbnRlbnQgMTwvaDE+CjxwPmNvbnRlbnQgMTwvcD4=
+                        content_type: text/html
                   payment:
                     payable: true
                     currency: SEK
@@ -2325,13 +2325,13 @@ paths:
                   generated_at: "2016-12-12"
                   type: "letter"
                   parts:
-                    name: document.pdf
-                    data: REVBREJFRUY=
-                    content_type: application/pdf
-                    responsive_part:
-                      name: document.html
-                      data: PGgxPmNvbnRlbnQgMTwvaDE+CjxwPmNvbnRlbnQgMTwvcD4=
-                      content_type: text/html
+                    - name: document.pdf
+                      data: REVBREJFRUY=
+                      content_type: application/pdf
+                      responsive_part:
+                        name: document.html
+                        data: PGgxPmNvbnRlbnQgMTwvaDE+CjxwPmNvbnRlbnQgMTwvcD4=
+                        content_type: text/html
               form to user:
                 value:
                   ssn: "191212121212"
@@ -2344,13 +2344,13 @@ paths:
                       internal_id: 6eb7d1b9-ccd6-408f-ade7-9a1837be3ecf
                     days_to_expiry: 30
                   parts:
-                    name: document.pdf
-                    data: REVBREJFRUY=
-                    content_type: application/pdf
-                    responsive_part:
-                      name: document.html
-                      data: PGgxPmNvbnRlbnQgMTwvaDE+CjxwPmNvbnRlbnQgMTwvcD4=
-                      content_type: text/html
+                    - name: document.pdf
+                      data: REVBREJFRUY=
+                      content_type: application/pdf
+                      responsive_part:
+                        name: document.html
+                        data: PGgxPmNvbnRlbnQgMTwvaDE+CjxwPmNvbnRlbnQgMTwvcD4=
+                        content_type: text/html
               campaign to user:
                 value:
                   ssn: "191212121212"
@@ -2360,13 +2360,13 @@ paths:
                   campaign:
                     tag: summer_2023
                   parts:
-                    name: document.pdf
-                    data: REVBREJFRUY=
-                    content_type: application/pdf
-                    responsive_part:
-                      name: document.html
-                      data: PGgxPmNvbnRlbnQgMTwvaDE+CjxwPmNvbnRlbnQgMTwvcD4=
-                      content_type: text/html
+                    - name: document.pdf
+                      data: REVBREJFRUY=
+                      content_type: application/pdf
+                      responsive_part:
+                        name: document.html
+                        data: PGgxPmNvbnRlbnQgMTwvaDE+CjxwPmNvbnRlbnQgMTwvcD4=
+                        content_type: text/html
 
   # ##############################################
   # POST, GET /v1/tenant/tenantKey/form


### PR DESCRIPTION
Several examples of /v2/tenant/TKEY/content had parts as object instead of array, fixed here