### PR TITLE
Split swagger.yml into separate files

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -2,30 +2,7 @@ steps:
   - name: "gcr.io/cloud-builders/gsutil"
     entrypoint: "bash"
     args:
-      - "-c"
-      - '[[ "$BRANCH_NAME" != "master" ]] && gsutil cp index.html swagger.yml "gs://developer.kivra.com/$BRANCH_NAME/" || echo "skipping . . ."'
-  - name: "gcr.io/cloud-builders/gsutil"
-    entrypoint: "bash"
-    args:
-      - "-c"
-      - '[[ "$BRANCH_NAME" != "master" ]] && gsutil cp -r receipt "gs://developer.kivra.com/$BRANCH_NAME/" || echo "skipping . . ."'
-  - name: "gcr.io/cloud-builders/gsutil"
-    entrypoint: "bash"
-    args:
-      - "-c"
-      - '[[ "$BRANCH_NAME" != "master" ]] && gsutil cp -r assets "gs://developer.kivra.com/$BRANCH_NAME/" || echo "skipping . . ."'
-  - name: "gcr.io/cloud-builders/gsutil"
-    entrypoint: "bash"
-    args:
-      - "-c"
-      - '[[ "$BRANCH_NAME" == "master" ]] && gsutil cp index.html swagger.yml "gs://developer.kivra.com/" || echo "skipping . . ."'
-  - name: "gcr.io/cloud-builders/gsutil"
-    entrypoint: "bash"
-    args:
-      - "-c"
-      - '[[ "$BRANCH_NAME" == "master" ]] && gsutil cp -r receipt "gs://developer.kivra.com/" || echo "skipping . . ."'
-  - name: "gcr.io/cloud-builders/gsutil"
-    entrypoint: "bash"
-    args:
-      - "-c"
-      - '[[ "$BRANCH_NAME" == "master" ]] && gsutil cp -r assets "gs://developer.kivra.com/" || echo "skipping . . ."'
+      - "script/cloudbuild.sh"
+      # BRANCH_NAME is not an environment variable, but a Cloud Build substitution variable.
+      # https://cloud.google.com/cloud-build/docs/configuring-builds/substitute-variable-values
+      - "$BRANCH_NAME"

--- a/script/cloudbuild.sh
+++ b/script/cloudbuild.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [[ "$1" == "master" ]]; then
+    target="gs://developer.kivra.com/"
+else
+    target="gs://developer.kivra.com/$1/"
+fi
+
+echo "Deploying to $target"
+
+gsutil cp index.html swagger.yml $target
+gsutil cp -r assets $target
+gsutil cp -r receipt $target
+gsutil cp -r v1 $target
+gsutil cp -r v3 $target

--- a/swagger.yml
+++ b/swagger.yml
@@ -2803,409 +2803,55 @@ paths:
   # GET /v1/partner/company
   # ##############################################
   /v1/partner/company:
-    get:
-      tags:
-        - "Partner API v1"
-      summary: Lookup a specific company
-      operationId: Find Company
-      description: |
-        This resource allows a partner to look if a specific company has granted access to its mailbox.
-        <aside class="notice">
-        If a search is done and the Company doesn’t exist in Kivra or has not granted access to the partner, an empty list will be returned.
-        </aside>
-      parameters:
-        - name: vat_number
-          in: query
-          description: Perform a search to see if a specific Company is available for access
-          required: true
-          schema:
-            description: Company's unique VAT number
-            type: string
-            example: SE556840226601
-      security:
-        - oAuth2Client:
-            - "get:kivra.v1.partner.company"
-      responses:
-        200:
-          description: Company key for the company with the matching VAT number
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  key:
-                    description: Company's unique Key
-                    type: string
-                    example: "15236156848eefa1dc75364af2be38c98eb3aae223"
+    $ref: v1/partner/company.yaml
 
   # ##############################################
   # GET /v1/partner/company/COMPKEY/content
   # ##############################################
   /v1/partner/company/{companyKey}/content:
-    get:
-      tags:
-        - "Partner API v1"
-      summary: Get the company inbox
-      operationId: Get company inbox
-      description: This resource allows to access a high level description for each content in the company inbox, to allow for a first sorting and filtering of the content.
-      parameters:
-        - name: companyKey
-          in: path
-          description: The unique key for the company object being retrieved
-          required: true
-          schema:
-            description: Company's unique key
-            type: string
-      security:
-        - oAuth2Client:
-            - "get:kivra.v1.partner.company.{companyKey}"
-      responses:
-        200:
-          description: High level description of content items in the company inbox
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/CompanyInbox"
+    $ref: v1/partner/company/{companyKey}/content.yaml
 
   # ##############################################
   # GET /v1/partner/company/COMPKEY/content/CONTKEY
   # ##############################################
   /v1/partner/company/{companyKey}/content/{contentKey}:
-    get:
-      tags:
-        - "Partner API v1"
-      summary: Get metadata for a content.
-      operationId: Get content metadata
-      description:
-        This resource allows to get complete metadata information for a particular content.
-        <aside class="notice">
-        Depending on the `content_type` for each parts of the content, Kivra will return either a `key` to a binary file to be retrieved or (for text based contents) the `body` of the content itself.
-        </aside>
-      parameters:
-        - name: companyKey
-          in: path
-          description: The unique key for the company object being retrieved
-          required: true
-          schema:
-            description: Company's unique key
-            type: string
-        - name: contentKey
-          in: path
-          description: The unique key for a specific content
-          required: true
-          schema:
-            description: Content's unique key
-            type: string
-      security:
-        - oAuth2Client:
-            - "get:kivra.v1.partner.company.{companyKey}.**"
-      responses:
-        200:
-          description: Complete metadata for the specific content
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/CompanyContent"
+    $ref: v1/partner/company/{companyKey}/content/{contentKey}.yaml
 
   # ##############################################
   # GET /v1/partner/company/COMPKEY/content/CONTKEY/file/FKEY/raw
   # ##############################################
   /v1/partner/company/{companyKey}/content/{contentKey}/file/{fileKey}/raw:
-    get:
-      tags:
-        - "Partner API v1"
-      summary: Get raw file in binary format
-      operationId: Get raw file
-      description: This resource allows to get the raw file in binary format.
-      parameters:
-        - name: companyKey
-          in: path
-          description: The unique key for the company object being retrieved
-          required: true
-          schema:
-            description: Company's unique key
-            type: string
-        - name: contentKey
-          in: path
-          description: The unique key for a specific content
-          required: true
-          schema:
-            description: Content's unique key
-            type: string
-        - name: fileKey
-          in: path
-          description: The unique key for a specific file
-          required: true
-          schema:
-            description: File's unique key
-            type: string
-      security:
-        - oAuth2Client:
-            - "get:kivra.v1.partner.company.{companyKey}.**"
-      responses:
-        200:
-          description: The content type will be the same as the file, so for a typical pdf it will be `application/pdf`
-          content:
-            application/json:
-              schema:
-                type: string
-                format: binary
+    $ref: v1/partner/company/{companyKey}/content/{contentKey}/file/{fileKey}/raw.yaml
 
   # ##############################################
   # POST /v1/partner/company/COMPKEY/content/CONTKEY/STATUS
   # ##############################################
   /v1/partner/company/{companyKey}/content/{contentKey}/{status}:
-    post:
-      tags:
-        - "Partner API v1"
-      summary: Set status for content
-      operationId: Set status for content
-      description: This resource allows to set the status for a specific content. It is used by the partner to set whether the content should be marked as viewed or paid.
-      parameters:
-        - name: companyKey
-          in: path
-          description: The unique key for the company object being retrieved
-          required: true
-          schema:
-            description: Company's unique key
-            type: string
-        - name: contentKey
-          in: path
-          description: The unique key for a specific content
-          required: true
-          schema:
-            description: Content's unique key
-            type: string
-        - name: status
-          in: path
-          description: The specific state to be set for this content, can be `paid`, `unpaid`, `view` or `unview`
-          required: true
-          schema:
-            description: The new state to be set for the content
-            type: string
-      security:
-        - oAuth2Client:
-            - "get:kivra.v1.partner.company.{companyKey}.**"
-      responses:
-        204:
-          description: empty response confirming that the operation was successful
-      requestBody:
-        description: empty JSON body
-        content:
-          application/json:
-            schema: {}
+    $ref: v1/partner/company/{companyKey}/content/{contentKey}/{status}.yaml
 
   # ##############################################
   # GET /v3/partner/company
   # ##############################################
   /v3/partner/company:
-    get:
-      tags:
-        - "Partner API v3"
-      summary: List accessible companies
-      operationId: List companies
-      description: List the companies the client has access to
-      parameters:
-        - name: field
-          in: query
-          schema:
-            type: array
-            items:
-              $ref: "#/components/schemas/FieldQueryParameter"
-        - name: vat_number
-          in: query
-          schema:
-            type: array
-            items:
-              $ref: "#/components/schemas/VatNumber"
-      responses:
-        "200":
-          description: >
-            If `vat_number` is given, the repsonse will only include companies with VAT numbers in that list.
-            The `field` parameter controls which columns (CSV) or properties (JSON) to include in the response.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/BaseCompany"
-            text/csv:
-              schema:
-                example: |
-                  key,type,name,vat_number
-                  2156077433683911cdca5fd4563bded979572454cb9,company,Cornelias
-                  Café AB,SE556000475501
-                type: string
+    $ref: v3/partner/company.yaml
 
   # ##############################################
   # GET /v3/partner/company/COMPKEY
   # ##############################################
   /v3/partner/company/{companyKey}:
-    get:
-      tags:
-        - "Partner API v3"
-      summary: Get a single company
-      operationId: Get company
-      description: Get a single company
-      parameters:
-        - name: companyKey
-          in: path
-          required: true
-          schema:
-            $ref: "#/components/schemas/CompanyKey"
-        - name: field
-          in: query
-          schema:
-            type: array
-            items:
-              $ref: "#/components/schemas/FieldQueryParameter"
-      responses:
-        "200":
-          description: ""
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/FullCompany"
+    $ref: v3/partner/company/{companyKey}.yaml
 
   # ##############################################
   # GET /v3/partner/company/COMPKEY/content
   # ##############################################
   /v3/partner/company/{companyKey}/content:
-    get:
-      tags:
-        - "Partner API v3"
-      summary: List company inbox content
-      operationId: GET_company-companyKey-content
-      description: |
-        List the content this company has received.
-        This may be filtered by certain `labels` and specific fields may be selected using `field`.
-
-        Note that more content metadata is available via the
-        [Get specific content](#tag/Partner-API-v3/operation/Get%20content) endpoint.
-      parameters:
-        - name: companyKey
-          in: path
-          required: true
-          schema:
-            $ref: "#/components/schemas/CompanyKey"
-        - name: handled
-          in: query
-          schema:
-            $ref: "#/components/schemas/HandledLabel"
-        - name: viewed
-          in: query
-          schema:
-            $ref: "#/components/schemas/ViewedLabel"
-        - name: field
-          in: query
-          schema:
-            type: array
-            items:
-              $ref: "#/components/schemas/FieldQueryParameter"
-      responses:
-        "200":
-          description: ""
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/BaseContentMetadata"
+    $ref: v3/partner/company/{companyKey}/content.yaml
 
   # ##############################################
   # GET,PATCH /v3/partner/company/COMPKEY/content/CONTKEY
   # ##############################################
   /v3/partner/company/{companyKey}/content/{contentKey}:
-    get:
-      tags:
-        - "Partner API v3"
-      summary: Get specific content
-      description: |
-        ### Content metadata
-
-        Get metadata about a specific content in JSON format.
-
-        If the interpreter service is enabled for a recipient, it can add structured metadata to content which has been received.
-        The `interpreted` label indicates if the interpreter has run for a given content.
-        Interpreted data is never used in place of metadata provided by the sender or Kivra, it can only be added.
-        Any property of the response that was added by the interpreter is clearly identified as such.
-        If an interpreted property is an object, it will have an `interpreted` property which is `true`.
-        If an interpreted property is a primitive value, its key path will be present in the `interpreted_fields` property.
-        See the response schema below for details.
-
-        ### Content file data
-
-        A given content can contain multiple files ("parts"). Fetching of such parts is done by passing the `part` query parameter.
-
-        A part can also be selected by setting the `Accept` header to the MIME type of the part you want
-        (see `parts` in the metadata JSON response). You will receive the first part that matches the given
-        MIME type.
-      operationId: Get content
-      parameters:
-        - name: companyKey
-          in: path
-          required: true
-          schema:
-            $ref: "#/components/schemas/CompanyKey"
-        - name: contentKey
-          in: path
-          required: true
-          schema:
-            $ref: "#/components/schemas/ContentKey"
-        - name: part
-          in: query
-          schema:
-            $ref: "#/components/schemas/PartQueryParameter"
-      responses:
-        "200":
-          description: Content metadata
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/FullContentMetadata"
-            "*/*":
-              schema:
-                $ref: "#/components/schemas/ContentPart"
-    patch:
-      tags:
-        - "Partner API v3"
-      summary: Update content metadata
-      operationId: Update content metadata
-      parameters:
-        - name: companyKey
-          in: path
-          required: true
-          schema:
-            $ref: "#/components/schemas/CompanyKey"
-        - name: contentKey
-          in: path
-          required: true
-          schema:
-            $ref: "#/components/schemas/ContentKey"
-      responses:
-        "200":
-          description: Content metadata
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/FullContentMetadata"
-            "*/*":
-              schema:
-                $ref: "#/components/schemas/ContentPart"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              additionalProperties: false
-              properties:
-                handled:
-                  description: Mark the content as `handled`/`unhandled`
-                  $ref: "#/components/schemas/HandledLabel"
-                viewed:
-                  description: Mark the content as `viewed`/`unviewed`
-                  $ref: "#/components/schemas/ViewedLabel"
-              type: object
-        required: true
+    $ref: v3/partner/company/{companyKey}/content/{contentKey}.yaml
 
 components:
   schemas:

--- a/swagger.yml
+++ b/swagger.yml
@@ -43,7 +43,7 @@ info:
 
 
     ## The service
-    Kivra is a secure digital mailbox tied to your personal or company identity 
+    Kivra is a secure digital mailbox tied to your personal or company identity
     in which you receive documents from companies, organizations
     and government agencies that are connected to Kivra. With Kivra you can
     receive, manage and archive your content wherever you are and on every
@@ -108,8 +108,8 @@ info:
     | 2023-11-22 | Added campaigns by tag to content |
     | 2023-11-23 | Grace period changed from 45 to 10 days |
     | 2023-12-11 | Declared v1 of content & payment metadata as obsolete, added type and subject as mandatory |
-    | 2023-12-12 | Removed Forms BETA tags since all Forms features are live | 
-    | 2024-03-21 | Added Invite to content with BETA tags | 
+    | 2023-12-12 | Removed Forms BETA tags since all Forms features are live |
+    | 2024-03-21 | Added Invite to content with BETA tags |
     | 2024-09-18 | Removed Invite BETA tags since invite features are live |
     | 2024-09-30 | Removed obsolete `v1` of `content` endpoint and `payment` structure |
 
@@ -464,8 +464,8 @@ info:
 
     Kivra's agreement service is not directly connected to Kivra's mailbox, and parties in an agreement do not need to be users of Kivra to use the service. However signers that are users of Kivra (or become Kivra users during the signing process) will have the benefit that the covenant file will be automatically transferred to their mailbox once the agreement is signed.
 
-    Note: the Signatures service works best when the original PDF content is an A4 document with all its pages in portrait mode. If size and orientation are different, 
-    the resulting covenant might look stretched, while the original document (included in the covenant) will be preserved in its original 
+    Note: the Signatures service works best when the original PDF content is an A4 document with all its pages in portrait mode. If size and orientation are different,
+    the resulting covenant might look stretched, while the original document (included in the covenant) will be preserved in its original
     size and orientation.
 
     ## Signers, Delegates and Parties
@@ -1262,9 +1262,9 @@ paths:
       summary: List available recipient users for a tenant (LEGACY)
       operationId: List Users
       description: |
-        LEGACY: This resource is only supported for existing customers, new integrations 
+        LEGACY: This resource is only supported for existing customers, new integrations
         should use the `usermatch` resource.
-        
+
         This resource is used to list all or search for users that are eligible
         for receiving Content from the specific Tenant. The response is a JSON
         list of Objects containing the User's key and SSN. The `diffId`
@@ -1337,9 +1337,9 @@ paths:
         List recipient users that were added/removed since a previous request (LEGACY)
       operationId: List Users Diff
       description: |
-        LEGACY: This resource is only supported for existing customers, new integrations 
+        LEGACY: This resource is only supported for existing customers, new integrations
         should use the `usermatch` resource.
-        
+
         This resource is used to list users that were added/removed since
         `diffId` was obtained, either from an initial request to the
         `/v1/tenant/{tenantKey}/user` endpoint, or from a subsequent request
@@ -1349,7 +1349,7 @@ paths:
         every 31 days.
         Also, due to the fact that grace period for users leaving Kivra is 10 days, after which
         all data about the user is erased from Kivra, it is crucial
-        that a new DIFF is requested at least once every 10 days to make sure that the list 
+        that a new DIFF is requested at least once every 10 days to make sure that the list
         of removed users is complete.
       parameters:
         - name: tenantKey
@@ -1786,8 +1786,6 @@ paths:
         404:
           description: |
             The diffId does not exist
-
-
 
   # ##############################################
   # POST /v2/tenant/TKEY/content
@@ -3378,7 +3376,7 @@ components:
               This content types enables long due dates with a longer notification scheme
             - `"invoice.renewal"`: |
               indicating that the content is not a real invoice, but an offer that is voluntary to pay for the receiver.
-              It can be used to send an offer to renew a subscription, insurance or similar. 
+              It can be used to send an offer to renew a subscription, insurance or similar.
               A valid `payment_multiple_options` object needs to be provided and the `payable` attribute must be set to `true`.
             - `"invoice.debtcollection"`: |
               indicating that the content is a debt collection claim (in Swedish: "inkassokrav").
@@ -4002,7 +4000,7 @@ components:
             user choses to pay this invoice with Swish. The alias given must be
             one that is listed as available for the sender, or Swish will not be
             offered as a payment alternative. The value can be the string
-            `disable`, in order to override a default payee alias and disable 
+            `disable`, in order to override a default payee alias and disable
             Swish payment for this invoice only.
         currency:
           type: string

--- a/v1/partner/company.yaml
+++ b/v1/partner/company.yaml
@@ -1,0 +1,34 @@
+get:
+  tags:
+    - "Partner API v1"
+  summary: Lookup a specific company
+  operationId: Find Company
+  description: |
+    This resource allows a partner to look if a specific company has granted access to its mailbox.
+    <aside class="notice">
+    If a search is done and the Company doesn’t exist in Kivra or has not granted access to the partner, an empty list will be returned.
+    </aside>
+  parameters:
+    - name: vat_number
+      in: query
+      description: Perform a search to see if a specific Company is available for access
+      required: true
+      schema:
+        description: Company's unique VAT number
+        type: string
+        example: SE556840226601
+  security:
+    - oAuth2Client:
+        - "get:kivra.v1.partner.company"
+  responses:
+    200:
+      description: Company key for the company with the matching VAT number
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              key:
+                description: Company's unique Key
+                type: string
+                example: "15236156848eefa1dc75364af2be38c98eb3aae223"

--- a/v1/partner/company/{companyKey}/content.yaml
+++ b/v1/partner/company/{companyKey}/content.yaml
@@ -1,0 +1,26 @@
+get:
+  tags:
+    - "Partner API v1"
+  summary: Get the company inbox
+  operationId: Get company inbox
+  description: This resource allows to access a high level description for each content in the company inbox, to allow for a first sorting and filtering of the content.
+  parameters:
+    - name: companyKey
+      in: path
+      description: The unique key for the company object being retrieved
+      required: true
+      schema:
+        description: Company's unique key
+        type: string
+  security:
+    - oAuth2Client:
+        - "get:kivra.v1.partner.company.{companyKey}"
+  responses:
+    200:
+      description: High level description of content items in the company inbox
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/CompanyInbox"

--- a/v1/partner/company/{companyKey}/content/{contentKey}.yaml
+++ b/v1/partner/company/{companyKey}/content/{contentKey}.yaml
@@ -1,0 +1,35 @@
+get:
+  tags:
+    - "Partner API v1"
+  summary: Get metadata for a content.
+  operationId: Get content metadata
+  description:
+    This resource allows to get complete metadata information for a particular content.
+    <aside class="notice">
+    Depending on the `content_type` for each parts of the content, Kivra will return either a `key` to a binary file to be retrieved or (for text based contents) the `body` of the content itself.
+    </aside>
+  parameters:
+    - name: companyKey
+      in: path
+      description: The unique key for the company object being retrieved
+      required: true
+      schema:
+        description: Company's unique key
+        type: string
+    - name: contentKey
+      in: path
+      description: The unique key for a specific content
+      required: true
+      schema:
+        description: Content's unique key
+        type: string
+  security:
+    - oAuth2Client:
+        - "get:kivra.v1.partner.company.{companyKey}.**"
+  responses:
+    200:
+      description: Complete metadata for the specific content
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/CompanyContent"

--- a/v1/partner/company/{companyKey}/content/{contentKey}/file/{fileKey}/raw.yaml
+++ b/v1/partner/company/{companyKey}/content/{contentKey}/file/{fileKey}/raw.yaml
@@ -1,0 +1,39 @@
+get:
+  tags:
+    - "Partner API v1"
+  summary: Get raw file in binary format
+  operationId: Get raw file
+  description: This resource allows to get the raw file in binary format.
+  parameters:
+    - name: companyKey
+      in: path
+      description: The unique key for the company object being retrieved
+      required: true
+      schema:
+        description: Company's unique key
+        type: string
+    - name: contentKey
+      in: path
+      description: The unique key for a specific content
+      required: true
+      schema:
+        description: Content's unique key
+        type: string
+    - name: fileKey
+      in: path
+      description: The unique key for a specific file
+      required: true
+      schema:
+        description: File's unique key
+        type: string
+  security:
+    - oAuth2Client:
+        - "get:kivra.v1.partner.company.{companyKey}.**"
+  responses:
+    200:
+      description: The content type will be the same as the file, so for a typical pdf it will be `application/pdf`
+      content:
+        application/json:
+          schema:
+            type: string
+            format: binary

--- a/v1/partner/company/{companyKey}/content/{contentKey}/{status}.yaml
+++ b/v1/partner/company/{companyKey}/content/{contentKey}/{status}.yaml
@@ -1,0 +1,39 @@
+post:
+  tags:
+    - "Partner API v1"
+  summary: Set status for content
+  operationId: Set status for content
+  description: This resource allows to set the status for a specific content. It is used by the partner to set whether the content should be marked as viewed or paid.
+  parameters:
+    - name: companyKey
+      in: path
+      description: The unique key for the company object being retrieved
+      required: true
+      schema:
+        description: Company's unique key
+        type: string
+    - name: contentKey
+      in: path
+      description: The unique key for a specific content
+      required: true
+      schema:
+        description: Content's unique key
+        type: string
+    - name: status
+      in: path
+      description: The specific state to be set for this content, can be `paid`, `unpaid`, `view` or `unview`
+      required: true
+      schema:
+        description: The new state to be set for the content
+        type: string
+  security:
+    - oAuth2Client:
+        - "get:kivra.v1.partner.company.{companyKey}.**"
+  responses:
+    204:
+      description: empty response confirming that the operation was successful
+  requestBody:
+    description: empty JSON body
+    content:
+      application/json:
+        schema: {}

--- a/v3/partner/company.yaml
+++ b/v3/partner/company.yaml
@@ -1,0 +1,35 @@
+get:
+  tags:
+    - "Partner API v3"
+  summary: List accessible companies
+  operationId: List companies
+  description: List the companies the client has access to
+  parameters:
+    - name: field
+      in: query
+      schema:
+        type: array
+        items:
+          $ref: "#/components/schemas/FieldQueryParameter"
+    - name: vat_number
+      in: query
+      schema:
+        type: array
+        items:
+          $ref: "#/components/schemas/VatNumber"
+  responses:
+    "200":
+      description: >
+        If `vat_number` is given, the repsonse will only include companies with VAT numbers in that list.
+        The `field` parameter controls which columns (CSV) or properties (JSON) to include in the response.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/BaseCompany"
+        text/csv:
+          schema:
+            type: string
+          example: |
+            key,type,name,vat_number
+            2156077433683911cdca5fd4563bded979572454cb9,company,Cornelias
+            Café AB,SE556000475501

--- a/v3/partner/company/{companyKey}.yaml
+++ b/v3/partner/company/{companyKey}.yaml
@@ -1,0 +1,26 @@
+get:
+  tags:
+    - "Partner API v3"
+  summary: Company information
+  operationId: Get company information
+  description: |
+    Get detailed information for a single company.
+  parameters:
+    - name: companyKey
+      in: path
+      required: true
+      schema:
+        $ref: "#/components/schemas/CompanyKey"
+    - name: field
+      in: query
+      schema:
+        type: array
+        items:
+          $ref: "#/components/schemas/FieldQueryParameter"
+  responses:
+    "200":
+      description: ""
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/FullCompany"

--- a/v3/partner/company/{companyKey}/content.yaml
+++ b/v3/partner/company/{companyKey}/content.yaml
@@ -1,0 +1,40 @@
+get:
+  tags:
+    - "Partner API v3"
+  summary: List company inbox
+  operationId: List content in the company inbox
+  description: |
+    List the content the company has received.
+    This may be filtered by certain `labels` and specific fields may be selected using `field`.
+
+    Note that more content metadata is available via the
+    [Get specific content](#tag/Partner-API-v3/operation/Get%20content) endpoint.
+  parameters:
+    - name: companyKey
+      in: path
+      required: true
+      schema:
+        $ref: "#/components/schemas/CompanyKey"
+    - name: handled
+      in: query
+      schema:
+        $ref: "#/components/schemas/HandledLabel"
+    - name: viewed
+      in: query
+      schema:
+        $ref: "#/components/schemas/ViewedLabel"
+    - name: field
+      in: query
+      schema:
+        type: array
+        items:
+          $ref: "#/components/schemas/FieldQueryParameter"
+  responses:
+    "200":
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/BaseContentMetadata"

--- a/v3/partner/company/{companyKey}/content/{contentKey}.yaml
+++ b/v3/partner/company/{companyKey}/content/{contentKey}.yaml
@@ -1,0 +1,86 @@
+get:
+  tags:
+    - "Partner API v3"
+  summary: Get specific content
+  description: |
+    ### Content metadata
+
+    Get metadata about a specific content in JSON format.
+
+    ### Content file data
+
+    A given content can contain multiple files ("parts"). Fetching of such parts is done by passing the `part` query parameter.
+
+    A part can also be selected by setting the `Accept` header to the MIME type of the part you want
+    (see `parts` in the metadata JSON response). You will receive the first part that matches the given
+    MIME type.
+  operationId: Get a specific company content
+  parameters:
+    - name: companyKey
+      in: path
+      required: true
+      schema:
+        $ref: "#/components/schemas/CompanyKey"
+    - name: contentKey
+      in: path
+      required: true
+      schema:
+        $ref: "#/components/schemas/ContentKey"
+    - name: part
+      in: query
+      schema:
+        $ref: "#/components/schemas/PartQueryParameter"
+  responses:
+    "200":
+      description: Content metadata
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/FullContentMetadata"
+        "*/*":
+          schema:
+            $ref: "#/components/schemas/ContentPart"
+patch:
+  tags:
+    - "Partner API v3"
+  summary: Update content metadata
+  operationId: Update company content metadata
+  parameters:
+    - name: companyKey
+      in: path
+      required: true
+      schema:
+        $ref: "#/components/schemas/CompanyKey"
+    - name: contentKey
+      in: path
+      required: true
+      schema:
+        $ref: "#/components/schemas/ContentKey"
+  responses:
+    "200":
+      description: Content metadata
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/FullContentMetadata"
+        "*/*":
+          schema:
+            $ref: "#/components/schemas/ContentPart"
+  requestBody:
+    content:
+      application/json:
+        schema:
+          additionalProperties: false
+          properties:
+            labels:
+              additionalProperties: false
+              properties:
+                handled:
+                  description: Mark the content as `handled`/`unhandled`
+                  $ref: "#/components/schemas/HandledLabel"
+                viewed:
+                  description: Mark the content as `viewed`/`unviewed`
+                  $ref: "#/components/schemas/ViewedLabel"
+              type: object
+          type: object
+    required: true


### PR DESCRIPTION
OpenAPI has support for multiple files using `$ref`. This uses that to split off the partner API into separate files. To make it easy to find the files I'm nameing them exactly like the `path` in the main swagger file.

There's one catch though. The cloudbuild has to be updated to include all the new files, and to not add to the pile of one-liners I'm moving the bash script into its own file. This has a caveat in that Cloud Build uses _substitutions_ instead of environment variables. The fix is easy enough, pass BRANCH_NAME as an explicit argument to the script.