### PR TITLE
[K4B-3382] Add VatNr to PAPI new content webhook

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -6381,11 +6381,17 @@ webhooks:
                   required:
                     - company_key
                     - content_key
+                    - vat_number
                   properties:
                     company_key:
                       $ref: "#/components/schemas/CompanyKey"
                     content_key:
                       $ref: "#/components/schemas/ContentKey"
+                    vat_number:
+                      pattern: ^SE[0-9]{10}01$
+                      description: The VAT number of the company that received the content.
+                      example: SE556000475501
+                      type: string
       responses:
         200:
           description: >


### PR DESCRIPTION
See [K4B-3382](https://kivra.atlassian.net/browse/K4B-3382).

See https://github.com/kivra/k4b_notification/pull/218.

[K4B-3382]: https://kivra.atlassian.net/browse/K4B-3382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ