### PR TITLE
Add: origin to PAPI

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -6404,6 +6404,26 @@ components:
         describes its file type.
 
     # ##############################################
+    # SCHEMA ContentOrigin
+    # ##############################################
+    ContentOrigin:
+      description: |
+        The origin of the content. Indicates how the content was delivered to Kivra.
+        - `kivra`: Sent directly through Kivra.
+        - `minameddelanden`: Sent via Mina Meddelanden. Used by governmental organisations.
+        - `user`: Uploaded by an user.
+        Companies with Kivra företag+ can also receive:
+        - `physical`: Physical post scanned by Kivra.
+        - `email`: Sent via the company's kivramail.com email address.
+      type: string
+      enum:
+        - kivra
+        - minameddelanden
+        - user
+        - physical
+        - email
+
+    # ##############################################
     # SCHEMA BaseContentMetadata
     # ##############################################
     BaseContentMetadata:
@@ -6475,6 +6495,8 @@ components:
           items:
             $ref: "#/components/schemas/VatNumber"
           nullable: true
+        origin:
+          $ref: "#/components/schemas/ContentOrigin"
         subject:
           description: Subject of the content
           example: "Invoice: a thousand Swiss rolls"


### PR DESCRIPTION
To be able to assert the authority and accuracy of content fetched through PAPI we want to provide the origin/source.

* `minameddelanden` for governmental post
* `user` for user uploaded content
* `email` for kivramail.com incoming email
* `physical` for scanned content
* `kivra` for everything else, aka commercial content